### PR TITLE
lib: Allow setting bootstrap address from hardware code information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "mediatek-brom"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediatek-brom"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For example to get the hardware code and version the following can be used over 
 ```rust,no_run
     use mediatek_brom::{io::BromExecute, Brom};
     # let mut transport = std::io::Cursor::new([0u8; 16]);
-    let brom = transport.execute(Brom::handshake(0x201000)).unwrap();
+    let brom = transport.execute(Brom::handshake()).unwrap();
     let hwcode = transport.execute(brom.hwcode()).unwrap();
     println!("Hwcode: {:x?}", hwcode);
 


### PR DESCRIPTION
Mediatek platforms might use different bootstrap addresses to load/execute the Download Agent (DA). In order to allow setting the right address from the retrieved hardware code information, the address field is made public and the proper From trait is implemented.

The address field is moved out the handshake Operation, as it isn't used by the handshake itself, rather is part of the Brom struct to be used later to load/execute the Download Agent).

The address 0x201000 is kept as the default value.