### PR TITLE
Make crate no_std compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,24 @@ jobs:
       - run: cargo clippy --features tokio -- -D warnings
       - run: cargo clippy --features futures -- -D warnings
 
+  no_std:
+    name: cargo check (no_std)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
+        with:
+          toolchain: "1.82"
+          targets: thumbv7em-none-eabihf
+      - run: cargo check --no-default-features --target thumbv7em-none-eabihf
+
   allgreen:
     if: always()
     needs:
       - test
       - fmt
       - clippy
+      - no_std
     runs-on: Ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,15 @@ repository = "https://github.com/boardswarm/mediatek-brom"
 readme = "README.md"
 
 [dependencies]
-thiserror = "2.0"
+thiserror = { version = "2.0", default-features = false }
 tokio = { version = "1.43.1", features = [ "io-util"], optional = true }
 futures = { version = "0.3", optional = true }
 
 [features]
-tokio = ["dep:tokio"]
-futures = ["dep:futures"]
+default = ["std"]
+std = ["thiserror/std"]
+tokio = ["std", "dep:tokio"]
+futures = ["std", "dep:futures"]
 
 [dev-dependencies]
 anyhow = "1.0.93"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
-use std::fmt::Debug;
+use core::fmt::Debug;
 
+#[cfg(feature = "std")]
 pub mod io;
 
 #[derive(Debug)]


### PR DESCRIPTION
I'm building some tooling around mediatek based fm350 modem.

no_std allows me to use this crate in more contexts. its a tiny change so I hope it will be easy to review